### PR TITLE
fix(ci): disable auto-merge for release-please PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,3 @@ jobs:
         with:
           release-type: simple
           token: ${{ secrets.RELEASE_PAT }}
-
-      - name: Auto-merge Release PR
-        if: steps.release.outputs.pr
-        run: |
-          PR_NUMBER=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.number')
-          gh pr merge "$PR_NUMBER" --squash
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## Summary
Removes automatic merging of release-please PRs to allow for manual review and control over release timing.

## Changes
- Removed the "Auto-merge Release PR" step from `.github/workflows/release.yml`
- Release PRs will now require manual review and merge

## Why
Release PRs were being automatically merged, which bypassed the opportunity for:
- Manual review of version bumps
- Verification of changelog accuracy
- Testing before release
- Control over release timing

## Test Plan
- [ ] Verify workflow file changes are correct
- [ ] Confirm release-please will still create PRs
- [ ] Confirm PRs will not auto-merge

Closes #5