### PR TITLE
fix: add noindex meta tag to prevent demo site indexing 🐛

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -31,6 +31,7 @@ const {
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, nofollow" />
   <meta name="description" content={description} />
   <title>{title} | FitCity Culemborg</title>
   <link rel="icon" type="image/png" href="/favicon.png" />


### PR DESCRIPTION
## Summary
- Added `<meta name="robots" content="noindex, nofollow">` to the base layout `<head>` to prevent search engines from indexing this demo site
- `robots.txt` already blocks crawling, but the meta tag is needed because Google can still index URLs discovered via external links

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)