### PR TITLE
fix: admin expandable rows and delete feature

### DIFF
--- a/functions/api/admin/contacts.ts
+++ b/functions/api/admin/contacts.ts
@@ -119,6 +119,33 @@ async function handlePatch(context: EventContext<Env, string, unknown>): Promise
   }
 }
 
+async function handleDelete(context: EventContext<Env, string, unknown>): Promise<Response> {
+  try {
+    const body = (await context.request.json()) as { id?: number };
+
+    if (!body.id) {
+      return jsonResponse({ error: 'ID is verplicht.' }, 400);
+    }
+
+    const existing = await context.env.DB.prepare(
+      'SELECT id FROM contacts WHERE id = ?'
+    ).bind(body.id).first();
+
+    if (!existing) {
+      return jsonResponse({ error: 'Bericht niet gevonden.' }, 404);
+    }
+
+    await context.env.DB.prepare('DELETE FROM contacts WHERE id = ?')
+      .bind(body.id)
+      .run();
+
+    return jsonResponse({ success: true });
+  } catch (err) {
+    console.error('Admin contacts DELETE error:', err);
+    return jsonResponse({ error: 'Serverfout bij verwijderen van bericht.' }, 500);
+  }
+}
+
 export const onRequest: PagesFunction<Env> = async (context) => {
   if (context.request.method === 'GET') {
     return handleGet(context);
@@ -126,6 +153,10 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
   if (context.request.method === 'PATCH') {
     return handlePatch(context);
+  }
+
+  if (context.request.method === 'DELETE') {
+    return handleDelete(context);
   }
 
   return new Response(JSON.stringify({ error: 'Method not allowed' }), {

--- a/functions/api/admin/signups.ts
+++ b/functions/api/admin/signups.ts
@@ -125,6 +125,33 @@ async function handlePatch(context: EventContext<Env, string, unknown>): Promise
   }
 }
 
+async function handleDelete(context: EventContext<Env, string, unknown>): Promise<Response> {
+  try {
+    const body = (await context.request.json()) as { id?: number };
+
+    if (!body.id) {
+      return jsonResponse({ error: 'ID is verplicht.' }, 400);
+    }
+
+    const existing = await context.env.DB.prepare(
+      'SELECT id FROM signups WHERE id = ?'
+    ).bind(body.id).first();
+
+    if (!existing) {
+      return jsonResponse({ error: 'Inschrijving niet gevonden.' }, 404);
+    }
+
+    await context.env.DB.prepare('DELETE FROM signups WHERE id = ?')
+      .bind(body.id)
+      .run();
+
+    return jsonResponse({ success: true });
+  } catch (err) {
+    console.error('Admin signups DELETE error:', err);
+    return jsonResponse({ error: 'Serverfout bij verwijderen van inschrijving.' }, 500);
+  }
+}
+
 export const onRequest: PagesFunction<Env> = async (context) => {
   if (context.request.method === 'GET') {
     return handleGet(context);
@@ -132,6 +159,10 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
   if (context.request.method === 'PATCH') {
     return handlePatch(context);
+  }
+
+  if (context.request.method === 'DELETE') {
+    return handleDelete(context);
   }
 
   return new Response(JSON.stringify({ error: 'Method not allowed' }), {

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -45,25 +45,17 @@ import Layout from '../../layouts/Layout.astro';
         <table class="admin-table" id="signups-table">
           <thead>
             <tr>
-              <th>#</th>
+              <th></th>
               <th>Status</th>
               <th>Datum</th>
               <th>Naam</th>
-              <th>Email</th>
-              <th>Telefoon</th>
-              <th>Geboortedatum</th>
-              <th>Adres</th>
-              <th>Postcode</th>
-              <th>Plaats</th>
               <th>Abonnement</th>
               <th>Prijs</th>
-              <th>Rekeninghouder</th>
-              <th>IBAN</th>
               <th>Acties</th>
             </tr>
           </thead>
           <tbody id="signups-body">
-            <tr><td colspan="15" class="table-loading">Laden...</td></tr>
+            <tr><td colspan="7" class="table-loading">Laden...</td></tr>
           </tbody>
         </table>
       </div>
@@ -75,24 +67,35 @@ import Layout from '../../layouts/Layout.astro';
         <table class="admin-table" id="contacts-table">
           <thead>
             <tr>
-              <th>#</th>
+              <th></th>
               <th>Status</th>
               <th>Datum</th>
               <th>Naam</th>
-              <th>Email</th>
               <th>Onderwerp</th>
-              <th>Bericht</th>
               <th>Acties</th>
             </tr>
           </thead>
           <tbody id="contacts-body">
-            <tr><td colspan="8" class="table-loading">Laden...</td></tr>
+            <tr><td colspan="6" class="table-loading">Laden...</td></tr>
           </tbody>
         </table>
       </div>
     </div>
 
   </main>
+
+  <!-- Delete confirmation modal -->
+  <div class="modal-overlay" id="delete-modal" style="display:none;">
+    <div class="modal-card">
+      <h3 class="modal-title">Verwijderen bevestigen</h3>
+      <p class="modal-text">Dit verwijdert alle gegevens permanent. Typ <strong>DELETE</strong> om te bevestigen.</p>
+      <input type="text" class="modal-input" id="delete-confirm-input" placeholder="Typ DELETE" autocomplete="off" />
+      <div class="modal-actions">
+        <button class="modal-btn modal-btn--cancel" id="delete-cancel">Annuleren</button>
+        <button class="modal-btn modal-btn--delete" id="delete-confirm" disabled>Verwijderen</button>
+      </div>
+    </div>
+  </div>
 </Layout>
 
 <style>
@@ -107,7 +110,7 @@ import Layout from '../../layouts/Layout.astro';
   }
 
   .admin-header-inner {
-    max-width: 1400px;
+    max-width: 1200px;
     margin: 0 auto;
     display: flex;
     align-items: center;
@@ -136,7 +139,7 @@ import Layout from '../../layouts/Layout.astro';
 
   /* ===================== ADMIN MAIN ===================== */
   .admin-main {
-    max-width: 1400px;
+    max-width: 1200px;
     margin: 0 auto;
     padding: 2rem 1.5rem;
   }
@@ -221,7 +224,6 @@ import Layout from '../../layouts/Layout.astro';
   .admin-table {
     width: 100%;
     border-collapse: collapse;
-    min-width: 1400px;
   }
 
   .admin-table th {
@@ -291,27 +293,153 @@ import Layout from '../../layouts/Layout.astro';
     color: #EF4444;
   }
 
-  /* ===================== STATUS SELECT ===================== */
+  /* ===================== EMPTY STATE ===================== */
+  .table-empty {
+    text-align: center;
+    color: var(--color-text-muted);
+    padding: 3rem 1rem !important;
+    font-size: 0.9rem;
+  }
+</style>
+
+<!-- Global styles for dynamically injected content (Astro scoped styles don't apply to innerHTML) -->
+<style is:global>
+  /* ===================== EXPANDABLE ROWS ===================== */
+  .row-summary {
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .row-summary:hover {
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  .row-summary.is-new {
+    font-weight: 600;
+  }
+
+  .row-summary.is-new td {
+    color: var(--color-text);
+  }
+
+  .row-expand-icon {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    transition: transform 0.2s;
+    display: inline-block;
+    width: 20px;
+    text-align: center;
+  }
+
+  .row-summary.is-open .row-expand-icon {
+    transform: rotate(90deg);
+  }
+
+  /* Detail row */
+  .row-detail {
+    display: none;
+    background: var(--color-surface);
+  }
+
+  .row-detail.is-open {
+    display: table-row;
+  }
+
+  .row-detail td {
+    padding: 0 !important;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .detail-inner {
+    padding: 1.25rem 1.5rem;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  @media (min-width: 768px) {
+    .detail-inner {
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+    }
+  }
+
+  .detail-group h4 {
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+    margin-bottom: 0.5rem;
+  }
+
+  .detail-group h4::after { display: none; }
+
+  .detail-row {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.3rem 0;
+    font-size: 0.85rem;
+    line-height: 1.4;
+  }
+
+  .detail-label {
+    color: var(--color-text-muted);
+    min-width: 110px;
+    flex-shrink: 0;
+  }
+
+  .detail-value {
+    color: var(--color-text);
+    word-break: break-word;
+  }
+
+  .detail-value a {
+    color: var(--color-primary);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  /* Message block for contacts */
+  .detail-message {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    padding: 1rem;
+    font-size: 0.875rem;
+    color: var(--color-text-body);
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin-top: 0.25rem;
+  }
+
+  /* ===================== STATUS SELECT (global for innerHTML) ===================== */
   .status-select {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     color: var(--color-text);
     font-family: var(--font-body);
     font-size: 0.8rem;
-    padding: 0.375rem 0.5rem;
+    padding: 0.375rem 2rem 0.375rem 0.5rem;
     border-radius: 0.25rem;
     cursor: pointer;
     min-width: 130px;
-  }
-
-  .status-select option {
-    background: #fff;
-    color: #141414;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23999' viewBox='0 0 24 24'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.5rem center;
   }
 
   .status-select:focus {
     outline: none;
     border-color: var(--color-primary);
+  }
+
+  .status-select option {
+    background: #ffffff;
+    color: #141414;
   }
 
   /* ===================== IBAN TOGGLE BUTTON ===================== */
@@ -335,12 +463,120 @@ import Layout from '../../layouts/Layout.astro';
     border-color: var(--color-primary);
   }
 
-  /* ===================== EMPTY STATE ===================== */
-  .table-empty {
-    text-align: center;
-    color: var(--color-text-muted);
-    padding: 3rem 1rem !important;
+  /* ===================== DELETE BUTTON ===================== */
+  .btn-delete {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    background: none;
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    color: #EF4444;
+    font-family: var(--font-body);
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.5rem 1rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s;
+    margin-top: 1rem;
+  }
+
+  .btn-delete:hover {
+    background: rgba(239, 68, 68, 0.1);
+    border-color: #EF4444;
+  }
+
+  /* ===================== DELETE MODAL ===================== */
+  .modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  .modal-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 2rem;
+    max-width: 400px;
+    width: 100%;
+  }
+
+  .modal-title {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    color: #EF4444;
+    margin-bottom: 0.75rem;
+  }
+
+  .modal-title::after { display: none; }
+
+  .modal-text {
     font-size: 0.9rem;
+    color: var(--color-text-body);
+    line-height: 1.5;
+    margin-bottom: 1rem;
+  }
+
+  .modal-input {
+    width: 100%;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+    font-family: var(--font-body);
+    font-size: 0.9rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.25rem;
+    margin-bottom: 1rem;
+  }
+
+  .modal-input:focus {
+    outline: none;
+    border-color: #EF4444;
+  }
+
+  .modal-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+  }
+
+  .modal-btn {
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 0.85rem;
+    padding: 0.5rem 1.25rem;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    transition: opacity 0.2s;
+  }
+
+  .modal-btn--cancel {
+    background: none;
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+  }
+
+  .modal-btn--delete {
+    background: #EF4444;
+    border: 1px solid #EF4444;
+    color: #fff;
+  }
+
+  .modal-btn--delete:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .modal-btn--delete:not(:disabled):hover {
+    opacity: 0.9;
   }
 </style>
 
@@ -360,6 +596,7 @@ import Layout from '../../layouts/Layout.astro';
     city: string;
     plan_name: string;
     plan_price: string;
+    plan_duration: string;
     account_holder: string;
     iban_masked: string;
   }
@@ -412,7 +649,9 @@ import Layout from '../../layouts/Layout.astro';
   const dutchMonths = ['jan', 'feb', 'mrt', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec'];
 
   function formatDutchDate(dateStr: string): string {
+    if (!dateStr) return '—';
     const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return dateStr;
     return `${d.getDate()} ${dutchMonths[d.getMonth()]} ${d.getFullYear()}`;
   }
 
@@ -447,54 +686,122 @@ import Layout from '../../layouts/Layout.astro';
     set('stat-activated', counts.activated);
   }
 
+  // ===================== HELPERS =====================
+  function escapeHtml(str: string): string {
+    const div = document.createElement('div');
+    div.textContent = str || '';
+    return div.innerHTML;
+  }
+
+  function detailRow(label: string, value: string, isLink = false): string {
+    const val = isLink ? value : escapeHtml(value || '—');
+    return `<div class="detail-row"><span class="detail-label">${label}</span><span class="detail-value">${val}</span></div>`;
+  }
+
+  // ===================== SELECT HTML (with inline option styles for cross-browser) =====================
+  function signupSelectHtml(id: number, status: string): string {
+    const opts = [
+      { value: 'new', label: 'Nieuw' },
+      { value: 'contacted', label: 'Contact gelegd' },
+      { value: 'activated', label: 'Geactiveerd' },
+      { value: 'cancelled', label: 'Geannuleerd' },
+    ];
+    return `<select class="status-select" data-signup-id="${id}" onchange="handleSignupStatusChange(this)">
+      ${opts.map(o => `<option value="${o.value}" ${status === o.value ? 'selected' : ''}>${o.label}</option>`).join('')}
+    </select>`;
+  }
+
+  function contactSelectHtml(id: number, status: string): string {
+    const opts = [
+      { value: 'new', label: 'Nieuw' },
+      { value: 'replied', label: 'Beantwoord' },
+      { value: 'closed', label: 'Gesloten' },
+    ];
+    return `<select class="status-select" data-contact-id="${id}" onchange="handleContactStatusChange(this)">
+      ${opts.map(o => `<option value="${o.value}" ${status === o.value ? 'selected' : ''}>${o.label}</option>`).join('')}
+    </select>`;
+  }
+
   // ===================== RENDER SIGNUPS TABLE =====================
   function renderSignupsTable(signups: Signup[]) {
     const tbody = document.getElementById('signups-body') as HTMLTableSectionElement;
     if (!tbody) return;
 
     if (signups.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="15" class="table-empty">Geen inschrijvingen gevonden</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="7" class="table-empty">Geen inschrijvingen gevonden</td></tr>';
       return;
     }
 
-    tbody.innerHTML = signups.map((s, i) => {
+    tbody.innerHTML = signups.map((s) => {
       const isNew = s.status === 'new';
-      const rowWeight = isNew ? 'font-weight: 600;' : 'font-weight: 400;';
-      const nameStyle = isNew ? 'font-weight: 700; color: var(--color-text);' : 'font-weight: 400; color: var(--color-text-body);';
-      return `
-      <tr style="${rowWeight}">
-        <td>${i + 1}</td>
+      const newClass = isNew ? ' is-new' : '';
+
+      // Summary row
+      const summary = `
+      <tr class="row-summary${newClass}" data-detail="signup-${s.id}">
+        <td><span class="row-expand-icon">&#9654;</span></td>
         <td>${badgeHtml(s.status)}</td>
-        <td style="white-space: nowrap;">${formatDutchDate(s.created_at)}</td>
-        <td style="${nameStyle} white-space: nowrap;">${escapeHtml(s.full_name)}</td>
-        <td><a href="mailto:${escapeHtml(s.email)}">${escapeHtml(s.email)}</a></td>
-        <td style="white-space: nowrap;"><a href="tel:${escapeHtml(s.phone)}">${escapeHtml(s.phone)}</a></td>
-        <td style="white-space: nowrap;">${formatDutchDate(s.date_of_birth)}</td>
-        <td style="white-space: nowrap;">${escapeHtml(s.street)} ${escapeHtml(s.house_number)}</td>
-        <td style="white-space: nowrap;">${escapeHtml(s.postcode)}</td>
-        <td style="white-space: nowrap;">${escapeHtml(s.city)}</td>
-        <td style="white-space: nowrap;">${escapeHtml(s.plan_name)}</td>
-        <td style="white-space: nowrap;">${escapeHtml(s.plan_price)}</td>
-        <td style="white-space: nowrap;">${escapeHtml(s.account_holder)}</td>
-        <td style="font-family: monospace; font-size: 0.8rem; white-space: nowrap;">
-          <span id="iban-${s.id}">${escapeHtml(s.iban_masked)}</span>
-          <button class="iban-toggle" data-id="${s.id}" onclick="handleIbanToggle(this)" title="IBAN tonen">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
-              <circle cx="12" cy="12" r="3"/>
-            </svg>
-          </button>
-        </td>
-        <td>
-          <select class="status-select" data-signup-id="${s.id}" onchange="handleSignupStatusChange(this)">
-            <option value="new" ${s.status === 'new' ? 'selected' : ''}>Nieuw</option>
-            <option value="contacted" ${s.status === 'contacted' ? 'selected' : ''}>Contact gelegd</option>
-            <option value="activated" ${s.status === 'activated' ? 'selected' : ''}>Geactiveerd</option>
-            <option value="cancelled" ${s.status === 'cancelled' ? 'selected' : ''}>Geannuleerd</option>
-          </select>
+        <td style="white-space:nowrap;">${formatDutchDate(s.created_at)}</td>
+        <td style="white-space:nowrap;">${escapeHtml(s.full_name)}</td>
+        <td style="white-space:nowrap;">${escapeHtml(s.plan_name)}</td>
+        <td style="white-space:nowrap;">${escapeHtml(s.plan_price)}</td>
+        <td onclick="event.stopPropagation()">${signupSelectHtml(s.id, s.status)}</td>
+      </tr>`;
+
+      // Detail row
+      const detail = `
+      <tr class="row-detail" id="signup-${s.id}">
+        <td colspan="7">
+          <div class="detail-inner">
+            <div class="detail-group">
+              <h4>Contactgegevens</h4>
+              ${detailRow('Email', `<a href="mailto:${escapeHtml(s.email)}">${escapeHtml(s.email)}</a>`, true)}
+              ${detailRow('Telefoon', `<a href="tel:${escapeHtml(s.phone)}">${escapeHtml(s.phone)}</a>`, true)}
+              ${detailRow('Geboortedatum', formatDutchDate(s.date_of_birth))}
+            </div>
+            <div class="detail-group">
+              <h4>Adres</h4>
+              ${detailRow('Straat', (s.street || '') + ' ' + (s.house_number || ''))}
+              ${detailRow('Postcode', s.postcode)}
+              ${detailRow('Plaats', s.city)}
+            </div>
+            <div class="detail-group">
+              <h4>Abonnement</h4>
+              ${detailRow('Type', s.plan_name)}
+              ${detailRow('Prijs', s.plan_price)}
+              ${detailRow('Looptijd', s.plan_duration)}
+            </div>
+            <div class="detail-group">
+              <h4>Betaling</h4>
+              ${detailRow('Rekeninghouder', s.account_holder)}
+              <div class="detail-row">
+                <span class="detail-label">IBAN</span>
+                <span class="detail-value" style="font-family: monospace;">
+                  <span id="iban-${s.id}">${escapeHtml(s.iban_masked)}</span>
+                  <button class="iban-toggle" data-id="${s.id}" onclick="handleIbanToggle(this)" title="IBAN tonen">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                      <circle cx="12" cy="12" r="3"/>
+                    </svg>
+                  </button>
+                </span>
+              </div>
+            </div>
+            <div style="grid-column: 1 / -1;">
+              <button class="btn-delete" onclick="handleDelete('signup', ${s.id}, '${escapeHtml(s.full_name).replace(/'/g, "\\'")}')">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                Verwijderen
+              </button>
+            </div>
+          </div>
         </td>
       </tr>`;
+
+      return summary + detail;
     }).join('');
+
+    // Attach row toggle handlers
+    attachRowToggleHandlers();
   }
 
   // ===================== RENDER CONTACTS TABLE =====================
@@ -503,44 +810,70 @@ import Layout from '../../layouts/Layout.astro';
     if (!tbody) return;
 
     if (contacts.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="8" class="table-empty">Geen contactberichten gevonden</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="6" class="table-empty">Geen contactberichten gevonden</td></tr>';
       return;
     }
 
-    tbody.innerHTML = contacts.map((c, i) => {
+    tbody.innerHTML = contacts.map((c) => {
       const isNew = c.status === 'new';
-      const rowWeight = isNew ? 'font-weight: 600;' : 'font-weight: 400;';
-      const nameStyle = isNew ? 'font-weight: 700; color: var(--color-text);' : 'font-weight: 400; color: var(--color-text-body);';
-      return `
-      <tr style="${rowWeight}">
-        <td>${i + 1}</td>
+      const newClass = isNew ? ' is-new' : '';
+
+      const summary = `
+      <tr class="row-summary${newClass}" data-detail="contact-${c.id}">
+        <td><span class="row-expand-icon">&#9654;</span></td>
         <td>${badgeHtml(c.status)}</td>
-        <td>${formatDutchDate(c.created_at)}</td>
-        <td style="${nameStyle}">${escapeHtml(c.name)}</td>
-        <td><a href="mailto:${escapeHtml(c.email)}">${escapeHtml(c.email)}</a></td>
+        <td style="white-space:nowrap;">${formatDutchDate(c.created_at)}</td>
+        <td style="white-space:nowrap;">${escapeHtml(c.name)}</td>
         <td>${escapeHtml(c.subject)}</td>
-        <td>${escapeHtml(truncate(c.message, 50))}</td>
-        <td>
-          <select class="status-select" data-contact-id="${c.id}" onchange="handleContactStatusChange(this)">
-            <option value="new" ${c.status === 'new' ? 'selected' : ''}>Nieuw</option>
-            <option value="replied" ${c.status === 'replied' ? 'selected' : ''}>Beantwoord</option>
-            <option value="closed" ${c.status === 'closed' ? 'selected' : ''}>Gesloten</option>
-          </select>
+        <td onclick="event.stopPropagation()">${contactSelectHtml(c.id, c.status)}</td>
+      </tr>`;
+
+      const detail = `
+      <tr class="row-detail" id="contact-${c.id}">
+        <td colspan="6">
+          <div class="detail-inner" style="grid-template-columns: 1fr;">
+            <div class="detail-group">
+              <h4>Contactgegevens</h4>
+              ${detailRow('Email', `<a href="mailto:${escapeHtml(c.email)}">${escapeHtml(c.email)}</a>`, true)}
+            </div>
+            <div class="detail-group">
+              <h4>Bericht</h4>
+              <div class="detail-message">${escapeHtml(c.message)}</div>
+            </div>
+            <div>
+              <button class="btn-delete" onclick="handleDelete('contact', ${c.id}, '${escapeHtml(c.name).replace(/'/g, "\\'")}')">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                Verwijderen
+              </button>
+            </div>
+          </div>
         </td>
       </tr>`;
+
+      return summary + detail;
     }).join('');
+
+    attachRowToggleHandlers();
   }
 
-  // ===================== HELPERS =====================
-  function escapeHtml(str: string): string {
-    const div = document.createElement('div');
-    div.textContent = str || '';
-    return div.innerHTML;
-  }
+  // ===================== ROW TOGGLE =====================
+  function attachRowToggleHandlers() {
+    document.querySelectorAll('.row-summary').forEach(row => {
+      // Remove old listeners by cloning
+      const newRow = row.cloneNode(true) as HTMLElement;
+      row.parentNode?.replaceChild(newRow, row);
 
-  function truncate(str: string, len: number): string {
-    if (!str) return '';
-    return str.length > len ? str.slice(0, len) + '...' : str;
+      newRow.addEventListener('click', () => {
+        const detailId = newRow.getAttribute('data-detail');
+        if (!detailId) return;
+        const detailRow = document.getElementById(detailId);
+        if (!detailRow) return;
+
+        const isOpen = newRow.classList.contains('is-open');
+        newRow.classList.toggle('is-open');
+        detailRow.classList.toggle('is-open');
+      });
+    });
   }
 
   // ===================== DATA LOADING =====================
@@ -609,7 +942,7 @@ import Layout from '../../layouts/Layout.astro';
     }
   }
 
-  // Expose handlers to inline onchange (Astro script modules are isolated)
+  // Expose handlers globally (Astro script modules are isolated from inline handlers)
   (window as any).handleSignupStatusChange = function(select: HTMLSelectElement) {
     const id = parseInt(select.dataset.signupId || '0');
     updateSignupStatus(id, select.value);
@@ -625,7 +958,6 @@ import Layout from '../../layouts/Layout.astro';
     const span = document.getElementById(`iban-${id}`);
     if (!span) return;
 
-    // If already revealed, toggle back to masked
     if (btn.dataset.revealed === 'true') {
       span.textContent = btn.dataset.masked || '';
       btn.dataset.revealed = 'false';
@@ -637,7 +969,6 @@ import Layout from '../../layouts/Layout.astro';
       return;
     }
 
-    // Reveal
     btn.innerHTML = '...';
     const iban = await revealIban(id);
     if (iban) {
@@ -656,6 +987,66 @@ import Layout from '../../layouts/Layout.astro';
         <circle cx="12" cy="12" r="3"/>
       </svg>`;
     }
+  };
+
+  // ===================== DELETE WITH CONFIRMATION =====================
+  let pendingDeleteType = '';
+  let pendingDeleteId = 0;
+
+  const deleteModal = document.getElementById('delete-modal') as HTMLElement;
+  const deleteInput = document.getElementById('delete-confirm-input') as HTMLInputElement;
+  const deleteConfirmBtn = document.getElementById('delete-confirm') as HTMLButtonElement;
+  const deleteCancelBtn = document.getElementById('delete-cancel') as HTMLButtonElement;
+
+  deleteInput.addEventListener('input', () => {
+    deleteConfirmBtn.disabled = deleteInput.value !== 'DELETE';
+  });
+
+  deleteCancelBtn.addEventListener('click', () => {
+    deleteModal.style.display = 'none';
+    deleteInput.value = '';
+    deleteConfirmBtn.disabled = true;
+  });
+
+  deleteConfirmBtn.addEventListener('click', async () => {
+    if (deleteInput.value !== 'DELETE') return;
+
+    const endpoint = pendingDeleteType === 'signup'
+      ? '/api/admin/signups/'
+      : '/api/admin/contacts/';
+
+    try {
+      await fetch(endpoint, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: pendingDeleteId }),
+      });
+      loadData();
+    } catch (err) {
+      console.error('Delete failed:', err);
+    }
+
+    deleteModal.style.display = 'none';
+    deleteInput.value = '';
+    deleteConfirmBtn.disabled = true;
+  });
+
+  // Close on overlay click
+  deleteModal.addEventListener('click', (e) => {
+    if (e.target === deleteModal) {
+      deleteModal.style.display = 'none';
+      deleteInput.value = '';
+      deleteConfirmBtn.disabled = true;
+    }
+  });
+
+  (window as any).handleDelete = function(type: string, id: number, name: string) {
+    pendingDeleteType = type;
+    pendingDeleteId = id;
+    deleteModal.style.display = 'flex';
+    deleteInput.value = '';
+    deleteConfirmBtn.disabled = true;
+    deleteInput.focus();
   };
 
   // ===================== INIT =====================


### PR DESCRIPTION
## Summary
- Redesign admin tables with expandable rows — click to show/hide details
- Summary row shows: status, datum, naam, abonnement/onderwerp, acties dropdown
- Expanded view shows all SEPA fields, contact info, full messages
- Delete button with GitHub-style confirmation (type DELETE to confirm)
- New DELETE endpoints for signups and contacts APIs
- Fixed dropdown readability via `appearance:none` + `is:global` styles
- Removed horizontal scroll — table fits within 1200px viewport

## Test plan
- [ ] Click a signup row — should expand to show all details
- [ ] Click again — should collapse
- [ ] Status dropdown options should be readable (dark text)
- [ ] Click "Verwijderen" — modal appears requiring "DELETE" typed
- [ ] Type DELETE and confirm — row should be removed
- [ ] Contact messages show full text in expanded view

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)