### PR TITLE
fix: burger menu, hero scroll, Android toggle, mobile tables

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -270,48 +270,54 @@ const currentPath = Astro.url.pathname;
 </style>
 
 <script>
-  // Header scroll state
-  const header = document.getElementById('site-header');
-  if (header) {
-    const onScroll = () => {
-      header.classList.toggle('scrolled', window.scrollY > 50);
-    };
-    window.addEventListener('scroll', onScroll, { passive: true });
-    onScroll();
+  function initHeader() {
+    // Header scroll state
+    const header = document.getElementById('site-header');
+    if (header) {
+      const onScroll = () => {
+        header.classList.toggle('scrolled', window.scrollY > 50);
+      };
+      window.addEventListener('scroll', onScroll, { passive: true });
+      onScroll();
+    }
+
+    // Mobile menu toggle
+    const toggle = document.getElementById('menu-toggle');
+    const closeBtn = document.getElementById('menu-close');
+    const menu = document.getElementById('mobile-menu');
+    const backdrop = document.getElementById('menu-backdrop');
+
+    if (toggle && closeBtn && menu && backdrop) {
+      const openMenu = () => {
+        menu.classList.add('is-open');
+        backdrop.classList.add('is-open');
+        menu.setAttribute('aria-hidden', 'false');
+        toggle.setAttribute('aria-expanded', 'true');
+        document.body.style.overflow = 'hidden';
+      };
+      const closeMenu = () => {
+        menu.classList.remove('is-open');
+        backdrop.classList.remove('is-open');
+        menu.setAttribute('aria-hidden', 'true');
+        toggle.setAttribute('aria-expanded', 'false');
+        document.body.style.overflow = '';
+      };
+
+      toggle.addEventListener('click', openMenu);
+      closeBtn.addEventListener('click', closeMenu);
+      backdrop.addEventListener('click', closeMenu);
+      menu.querySelectorAll('a').forEach(link => link.addEventListener('click', closeMenu));
+
+      // Escape key closes menu
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && menu.classList.contains('is-open')) {
+          closeMenu();
+        }
+      });
+    }
   }
 
-  // Mobile menu toggle
-  const toggle = document.getElementById('menu-toggle');
-  const closeBtn = document.getElementById('menu-close');
-  const menu = document.getElementById('mobile-menu');
-  const backdrop = document.getElementById('menu-backdrop');
-
-  if (toggle && closeBtn && menu && backdrop) {
-    const openMenu = () => {
-      menu.classList.add('is-open');
-      backdrop.classList.add('is-open');
-      menu.setAttribute('aria-hidden', 'false');
-      toggle.setAttribute('aria-expanded', 'true');
-      document.body.style.overflow = 'hidden';
-    };
-    const closeMenu = () => {
-      menu.classList.remove('is-open');
-      backdrop.classList.remove('is-open');
-      menu.setAttribute('aria-hidden', 'true');
-      toggle.setAttribute('aria-expanded', 'false');
-      document.body.style.overflow = '';
-    };
-
-    toggle.addEventListener('click', openMenu);
-    closeBtn.addEventListener('click', closeMenu);
-    backdrop.addEventListener('click', closeMenu);
-    menu.querySelectorAll('a').forEach(link => link.addEventListener('click', closeMenu));
-
-    // Escape key closes menu
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && menu.classList.contains('is-open')) {
-        closeMenu();
-      }
-    });
-  }
+  // Run on initial load and after every view transition navigation
+  initHeader();
+  document.addEventListener('astro:after-swap', initHeader);
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -59,9 +59,9 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
     </div>
 
     <!-- Scroll indicator -->
-    <div class="hero-scroll" aria-hidden="true">
+    <button class="hero-scroll" aria-label="Scroll naar beneden" id="hero-scroll-btn" type="button">
       <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
-    </div>
+    </button>
   </section>
 
   <!-- ============================================
@@ -406,6 +406,20 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
       }
     }
 
+    // Hero scroll button
+    const scrollBtn = document.getElementById('hero-scroll-btn');
+    if (scrollBtn) {
+      scrollBtn.addEventListener('click', () => {
+        const hero = document.getElementById('hero');
+        if (hero) {
+          const nextSection = hero.nextElementSibling;
+          if (nextSection) {
+            nextSection.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
+      });
+    }
+
     // Pricing toggle
     const toggleBtns = document.querySelectorAll('.pricing-toggle-btn');
     const grids = document.querySelectorAll('[data-pricing-group]');
@@ -588,6 +602,15 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
     z-index: 2;
     color: var(--color-primary);
     animation: bounce 2s infinite;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.5rem;
+    min-width: 44px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   @keyframes bounce {
@@ -692,7 +715,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
 
   .service-card--fitness .service-card-title,
   .service-card--kickboxing .service-card-title { color: var(--color-primary); }
-  .service-card--ladies .service-card-title { color: var(--color-secondary); }
+  .service-card--ladies .service-card-title { color: var(--color-text); }
 
   .service-card-desc {
     color: var(--color-text-muted);
@@ -855,6 +878,11 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
     color: var(--color-text-muted);
     min-height: 44px;
     transition: background 0.2s, color 0.2s;
+    position: relative;
+    z-index: 1;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
   }
 
   .pricing-toggle-btn.active {

--- a/src/styles/inner-pages.css
+++ b/src/styles/inner-pages.css
@@ -207,6 +207,54 @@
   font-weight: 600;
 }
 
+/* Mobile: stack table rows as cards */
+@media (max-width: 767px) {
+  .pricing-table-wrap { overflow-x: visible; }
+
+  .pricing-table thead { display: none; }
+
+  .pricing-table tbody { display: flex; flex-direction: column; gap: 0.75rem; }
+
+  .pricing-table tr {
+    display: block;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background: var(--color-surface);
+  }
+
+  .pricing-table td {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0.25rem 0;
+    border-bottom: none;
+  }
+
+  .pricing-table td::before {
+    font-family: var(--font-body);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+    margin-right: 1rem;
+  }
+
+  .pricing-table td:first-child {
+    font-size: 1rem;
+    padding-bottom: 0.5rem;
+    margin-bottom: 0.25rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .pricing-table td:first-child::before { content: none; }
+  .pricing-table td:nth-child(2)::before { content: 'Prijs'; }
+  .pricing-table td:nth-child(3)::before { content: 'Duur'; }
+  .pricing-table td:nth-child(4)::before { content: 'Inclusief'; }
+}
+
 .pricing-note {
   font-size: 0.8rem;
   color: var(--color-text-muted);


### PR DESCRIPTION
## Summary
- **Burger menu** now works on all pages (not just homepage) — fixed Astro view transitions script re-binding via `astro:after-swap`
- **Hero chevron** arrow is now clickable, smooth-scrolls to next section
- **Android pricing toggle** (jaar/halfjaar/flex) touch targets fixed with `position: relative; z-index: 1; touch-action: manipulation`
- **Ladies Only card title** changed from pink to white (matches signup page)
- **Mobile pricing tables** on fitness/kickboxing/ladies-only pages now show as stacked cards instead of scrollable tables

## Test plan
- [ ] Open burger menu on every page (fitness, ladies-only, kickboxing, contact, etc.) — should slide in correctly
- [ ] Click hero chevron on homepage — should smooth scroll down
- [ ] Test jaar/halfjaar/flex toggle on Android device
- [ ] Verify Ladies Only card title is white on homepage
- [ ] Check pricing tables on mobile for fitness, kickboxing, ladies-only pages — should show as cards

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)