### PR TITLE
fix: menu transparency, hero video, table cards, footer layout

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -95,15 +95,17 @@ import { openingHours } from '../data/hours';
 
   .footer-grid {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: 2.5rem;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 2rem 1.5rem;
+  }
+
+  /* Brand column spans full width on mobile */
+  .footer-grid > div:first-child {
+    grid-column: 1 / -1;
   }
 
   @media (min-width: 768px) {
-    .footer-grid {
-      grid-template-columns: repeat(2, 1fr);
-      gap: 2rem;
-    }
+    .footer-grid > div:first-child { grid-column: auto; }
   }
 
   @media (min-width: 1024px) {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -25,25 +25,24 @@ const currentPath = Astro.url.pathname;
       <span></span>
     </button>
   </div>
-
-  <!-- Mobile menu overlay -->
-  <div class="mobile-menu" id="mobile-menu" aria-hidden="true">
-    <div class="mobile-menu-header">
-      <a href="/" class="header-logo"><img src="/images/fitcity-logo.webp" alt="Fitcity Culemborg" class="header-logo-img" /></a>
-      <button class="mobile-menu-close" id="menu-close" aria-label="Menu sluiten">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
-      </button>
-    </div>
-    <nav class="mobile-menu-nav" aria-label="Mobiel menu">
-      {mobileNav.map(item => (
-        <a href={item.href} class:list={{ 'nav-active': currentPath.startsWith(item.href) }}>{item.label}</a>
-      ))}
-    </nav>
-    <a href="/signup/" class="mobile-menu-cta">WORD NU LID</a>
-  </div>
-  <!-- Outside click overlay -->
-  <div class="mobile-menu-backdrop" id="menu-backdrop" aria-hidden="true"></div>
 </header>
+
+<!-- Mobile menu + backdrop live OUTSIDE header to avoid backdrop-filter transparency bug on mobile -->
+<div class="mobile-menu" id="mobile-menu" aria-hidden="true">
+  <div class="mobile-menu-header">
+    <a href="/" class="mobile-menu-logo"><img src="/images/fitcity-logo.webp" alt="Fitcity Culemborg" class="header-logo-img" /></a>
+    <button class="mobile-menu-close" id="menu-close" aria-label="Menu sluiten">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+    </button>
+  </div>
+  <nav class="mobile-menu-nav" aria-label="Mobiel menu">
+    {mobileNav.map(item => (
+      <a href={item.href} class:list={{ 'nav-active': currentPath.startsWith(item.href) }}>{item.label}</a>
+    ))}
+  </nav>
+  <a href="/signup/" class="mobile-menu-cta">WORD NU LID</a>
+</div>
+<div class="mobile-menu-backdrop" id="menu-backdrop" aria-hidden="true"></div>
 
 <style>
   .site-header {
@@ -169,11 +168,12 @@ const currentPath = Astro.url.pathname;
     background: var(--color-text);
   }
 
-  /* Mobile menu */
+  /* Mobile menu — lives outside <header> to avoid backdrop-filter bugs */
   .mobile-menu {
     position: fixed;
     inset: 0;
-    background: var(--color-bg);
+    background: #141414;
+    background: var(--color-bg, #141414);
     z-index: 200;
     display: flex;
     flex-direction: column;
@@ -183,6 +183,11 @@ const currentPath = Astro.url.pathname;
   }
 
   .mobile-menu.is-open { transform: translateX(0); }
+
+  .mobile-menu-logo {
+    display: flex;
+    align-items: center;
+  }
 
   .mobile-menu-backdrop {
     position: fixed;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -384,6 +384,17 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
   <Footer />
   <MobileCTA />
 
+  <!-- Restart hero video after view transition navigation -->
+  <script>
+    function restartHeroVideo() {
+      const video = document.querySelector('.hero-video') as HTMLVideoElement | null;
+      if (video) {
+        video.play().catch(() => {});
+      }
+    }
+    document.addEventListener('astro:page-load', restartHeroVideo);
+  </script>
+
   <!-- Scroll reveal fallback for Firefox -->
   <script>
     if (!CSS.supports('animation-timeline', 'view()')) {

--- a/src/styles/inner-pages.css
+++ b/src/styles/inner-pages.css
@@ -253,6 +253,13 @@
   .pricing-table td:nth-child(2)::before { content: 'Prijs'; }
   .pricing-table td:nth-child(3)::before { content: 'Duur'; }
   .pricing-table td:nth-child(4)::before { content: 'Inclusief'; }
+
+  /* Inclusief can have long text — stack label above value */
+  .pricing-table td:nth-child(4) {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.125rem;
+  }
 }
 
 .pricing-note {


### PR DESCRIPTION
## Summary
- **Mobile menu transparency**: moved `<div class="mobile-menu">` outside `<header>` — the header's `backdrop-filter: blur(12px)` was causing children to render transparent on mobile browsers (known WebKit bug)
- **Hero video black on navigation**: added `astro:page-load` listener to restart video autoplay after view transitions
- **Inclusief text wrapping**: mobile pricing cards now stack the Inclusief label above the value text instead of cramming both on one line
- **Footer mobile layout**: changed from single-column to 2-column grid so Openingstijden and Links sit side by side

## Test plan
- [ ] Open burger menu on mobile — background should be solid dark, not transparent
- [ ] Navigate to another page and click logo to return home — hero video should play
- [ ] Check pricing tables on mobile (fitness, kickboxing, ladies-only) — Inclusief text should not wrap awkwardly
- [ ] Check footer on mobile — Openingstijden and Links should be side by side

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)