### PR TITLE
fix: hero scroll chevron above mobile CTA bar

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -607,7 +607,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
 
   .hero-scroll {
     position: absolute;
-    bottom: 2rem;
+    bottom: 6rem;
     left: 50%;
     transform: translateX(-50%);
     z-index: 2;
@@ -622,6 +622,10 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+
+  @media (min-width: 768px) {
+    .hero-scroll { bottom: 2rem; }
   }
 
   @keyframes bounce {


### PR DESCRIPTION
## Summary
- Moved hero scroll chevron from `bottom: 2rem` to `bottom: 6rem` on mobile so it's visible above the sticky WORD NU LID bar
- Desktop keeps `bottom: 2rem` via `@media (min-width: 768px)`

## Test plan
- [ ] Check hero chevron is visible above the sticky CTA bar on mobile
- [ ] Check it's still at bottom on desktop

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)