### PR TITLE
fix: reviews pill mobile overflow, proeftraining deep link

### DIFF
--- a/src/pages/contact/index.astro
+++ b/src/pages/contact/index.astro
@@ -98,6 +98,18 @@ import { openingHours } from '../../data/hours';
   <MobileCTA />
 </Layout>
 
+<script>
+  // Pre-select onderwerp from query param (e.g. ?onderwerp=proeftraining)
+  const params = new URLSearchParams(window.location.search);
+  const onderwerp = params.get('onderwerp');
+  if (onderwerp) {
+    const select = document.getElementById('onderwerp') as HTMLSelectElement | null;
+    if (select) {
+      select.value = onderwerp;
+    }
+  }
+</script>
+
 <style>
   @import '../../styles/inner-pages.css';
 

--- a/src/pages/fitness/index.astro
+++ b/src/pages/fitness/index.astro
@@ -116,7 +116,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
     primaryLabel="WORD NU LID"
     primaryHref="/signup/"
     secondaryLabel="PLAN PROEFTRAINING"
-    secondaryHref="/contact/"
+    secondaryHref="/contact/?onderwerp=proeftraining#contact-form"
   />
 
   <!-- Related -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -378,7 +378,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
     primaryLabel="WORD NU LID"
     primaryHref="/signup/"
     secondaryLabel="PLAN PROEFTRAINING"
-    secondaryHref="/contact/"
+    secondaryHref="/contact/?onderwerp=proeftraining#contact-form"
   />
 
   <Footer />
@@ -526,12 +526,22 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
   }
 
   .hero-reviews-stars { display: flex; gap: 2px; }
-  .hero-reviews-rating { font-weight: 600; font-size: 1.1rem; color: var(--color-text); }
+  .hero-reviews-stars svg { width: 16px; height: 16px; }
+  .hero-reviews-rating { font-weight: 600; font-size: 0.95rem; color: var(--color-text); }
   .hero-reviews-sep { color: var(--color-separator); }
-  .hero-reviews-count { font-size: 0.875rem; color: var(--color-text-muted); }
+  .hero-reviews-count { font-size: 0.75rem; color: var(--color-text-muted); }
 
   .hero-reviews {
     text-decoration: none;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+  }
+
+  @media (min-width: 768px) {
+    .hero-reviews { gap: 0.75rem; padding: 0.625rem 1.25rem; }
+    .hero-reviews-stars svg { width: 20px; height: 20px; }
+    .hero-reviews-rating { font-size: 1.1rem; }
+    .hero-reviews-count { font-size: 0.875rem; }
   }
 
   .hero-title {

--- a/src/pages/kickboxing/index.astro
+++ b/src/pages/kickboxing/index.astro
@@ -96,7 +96,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
     </div>
   </section>
 
-  <CtaSection title="PROBEER EEN LES" text="Je eerste kickboxles is gratis en vrijblijvend. Neem gerust contact op of kom gewoon langs." primaryLabel="WORD NU LID" primaryHref="/signup/" secondaryLabel="PLAN PROEFTRAINING" secondaryHref="/contact/" />
+  <CtaSection title="PROBEER EEN LES" text="Je eerste kickboxles is gratis en vrijblijvend. Neem gerust contact op of kom gewoon langs." primaryLabel="WORD NU LID" primaryHref="/signup/" secondaryLabel="PLAN PROEFTRAINING" secondaryHref="/contact/?onderwerp=proeftraining#contact-form" />
 
   <section class="content-section"><div class="content-wide"><p class="related-heading">Ook interessant</p><div class="related-links"><a href="/fitness/" class="related-link">Fitness <span>Onbeperkt trainen</span></a><a href="/ladies-only/" class="related-link">Ladies Only <span>Fitness voor vrouwen</span></a></div></div></section>
 

--- a/src/pages/ladies-only/index.astro
+++ b/src/pages/ladies-only/index.astro
@@ -88,7 +88,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
     </div>
   </section>
 
-  <CtaSection title="PROBEER HET ZELF" text="Je eerste proefles is altijd gratis. Neem gerust contact op, of word direct lid." primaryLabel="WORD NU LID" primaryHref="/signup/" secondaryLabel="PLAN PROEFTRAINING" secondaryHref="/contact/" />
+  <CtaSection title="PROBEER HET ZELF" text="Je eerste proefles is altijd gratis. Neem gerust contact op, of word direct lid." primaryLabel="WORD NU LID" primaryHref="/signup/" secondaryLabel="PLAN PROEFTRAINING" secondaryHref="/contact/?onderwerp=proeftraining#contact-form" />
 
   <section class="content-section"><div class="content-wide"><p class="related-heading">Ook interessant</p><div class="related-links"><a href="/fitness/" class="related-link">Fitness <span>Onbeperkt trainen</span></a><a href="/kickboxing/" class="related-link">Kickboxing <span>Lessen voor alle niveaus</span></a></div></div></section>
 

--- a/src/pages/over-ons/index.astro
+++ b/src/pages/over-ons/index.astro
@@ -71,7 +71,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
     </div>
   </section>
 
-  <CtaSection title="BENIEUWD?" text="Kom gerust een keer langs voor een gratis proefles. Of word gewoon direct lid." primaryLabel="WORD NU LID" primaryHref="/signup/" secondaryLabel="PLAN PROEFTRAINING" secondaryHref="/contact/" />
+  <CtaSection title="BENIEUWD?" text="Kom gerust een keer langs voor een gratis proefles. Of word gewoon direct lid." primaryLabel="WORD NU LID" primaryHref="/signup/" secondaryLabel="PLAN PROEFTRAINING" secondaryHref="/contact/?onderwerp=proeftraining#contact-form" />
 
   <Footer />
   <MobileCTA />


### PR DESCRIPTION
## Summary
- **Reviews pill**: reduced star size (20→16px), font sizes, and gap on mobile so "29 Google Reviews" fits without cutoff. Desktop sizes restored at 768px+
- **PLAN PROEFTRAINING**: all 5 CTA buttons now deep link to `/contact/?onderwerp=proeftraining#contact-form` — auto-scrolls to form and pre-selects "Proeftraining plannen" in the dropdown

## Test plan
- [ ] Check hero reviews pill on mobile — "29 Google Reviews" should be fully visible
- [ ] Click any PLAN PROEFTRAINING button — should scroll to contact form with "Proeftraining plannen" pre-selected

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)