### PR TITLE
fix: Ladies Only pricing card title white

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -967,7 +967,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
   .pricing-card-name::after { display: none; }
 
   .pricing-card--primary .pricing-card-name { color: var(--color-text); }
-  .pricing-card--secondary .pricing-card-name { color: var(--color-secondary); }
+  .pricing-card--secondary .pricing-card-name { color: var(--color-text); }
 
   .pricing-card-price { margin-bottom: 0.25rem; }
 


### PR DESCRIPTION
## Summary
- Changed `.pricing-card--secondary .pricing-card-name` from `var(--color-secondary)` (pink) to `var(--color-text)` (white) to match signup page

## Test plan
- [ ] Check Ladies Only pricing card title in Prijzen section on homepage — should be white

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)