### PR TITLE
fix: hide phone in header on desktop

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -126,7 +126,7 @@ const currentPath = Astro.url.pathname;
   }
 
   @media (min-width: 1024px) {
-    .header-phone-text { display: inline; }
+    .header-phone { display: none; }
   }
 
   .header-cta {


### PR DESCRIPTION
## Summary
- Hide `.header-phone` at 1024px+ (desktop) — users can use the contact page instead
- Phone icon stays visible on mobile as a tap-to-call shortcut

## Test plan
- [ ] Desktop: phone number/icon should not appear in header
- [ ] Mobile: phone icon should still be visible and tappable

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)