### PR TITLE
fix: mobile page spacing, footer contact hidden, dagpas text

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -104,8 +104,14 @@ import { openingHours } from '../data/hours';
     grid-column: 1 / -1;
   }
 
+  /* Hide Contact column on mobile — info is on contact page */
+  .footer-grid > div:nth-child(4) {
+    display: none;
+  }
+
   @media (min-width: 768px) {
     .footer-grid > div:first-child { grid-column: auto; }
+    .footer-grid > div:nth-child(4) { display: block; }
   }
 
   @media (min-width: 1024px) {

--- a/src/data/pricing.ts
+++ b/src/data/pricing.ts
@@ -141,7 +141,7 @@ export const pricingPlans: Record<string, PricingPlan[]> = {
 };
 
 export const pricingExtras: PricingExtra[] = [
-  { name: 'Dagpas', price: '€7,00', note: 'Eenmalig, gewoon binnenlopen' },
+  { name: 'Dagpas', price: '€7,00', note: 'Eenmalig' },
   { name: 'Quick Deal', price: '€99,00', note: '3 maanden, eenmalige betaling' },
   { name: 'Combi Deal', price: '€39,50/maand', note: '12 maanden, voor 2 personen' },
   { name: 'Kickboxing los', price: 'vanaf €19,95/maand', note: 'Zie kickboxing pagina voor alle opties', href: '/kickboxing/' },

--- a/src/styles/inner-pages.css
+++ b/src/styles/inner-pages.css
@@ -6,7 +6,7 @@
 /* Inner hero */
 .inner-hero {
   background: var(--color-bg);
-  padding: 0 1.5rem 2rem;
+  padding: 0 1.5rem 1rem;
   position: relative;
 }
 
@@ -33,7 +33,7 @@
 /* Content sections */
 .content-section {
   background: var(--color-bg);
-  padding: 3rem 0;
+  padding: 1.5rem 0;
 }
 
 .content-section--alt {


### PR DESCRIPTION
## Summary
- **Mobile spacing**: reduced gap between page title and paragraph text from ~5rem to ~2.5rem on mobile (inner-hero 2rem→1rem bottom, content-section 3rem→1.5rem top). Desktop unchanged
- **Footer**: Contact column hidden on mobile (< 768px) — info available on contact page
- **Dagpas**: removed "gewoon binnenlopen" from note, now just "Eenmalig"

## Test plan
- [ ] Check spacing between page title and text on mobile (contact, fitness, etc.)
- [ ] Footer on mobile: should show Brand, Openingstijden, Links — no Contact
- [ ] Dagpas in pricing extras shows just "Eenmalig"

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)