### PR TITLE
chore: remove equipment brand names from all pages

### DIFF
--- a/src/pages/faq/index.astro
+++ b/src/pages/faq/index.astro
@@ -51,7 +51,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
       <h2 class="faq-category" id="faciliteiten">FACILITEITEN</h2>
 
       <div class="faq-list">
-        <details class="faq-item"><summary class="faq-question">Welke apparatuur hebben jullie?<span class="faq-icon">+</span></summary><div class="faq-answer"><p>We werken met apparatuur van Nautilus, SportsArt en Technogym. Dat zijn merken die je ook bij de grote ketens vindt. De fitnessvloer heeft cardio- en krachtapparatuur, vrije gewichten en functionele trainingsapparatuur. Alles wordt regelmatig onderhouden en waar nodig vernieuwd.</p></div></details>
+        <details class="faq-item"><summary class="faq-question">Welke apparatuur hebben jullie?<span class="faq-icon">+</span></summary><div class="faq-answer"><p>De fitnessvloer heeft cardio- en krachtapparatuur, vrije gewichten en functionele trainingsapparatuur. Alles wordt regelmatig onderhouden en waar nodig vernieuwd.</p></div></details>
 
         <details class="faq-item"><summary class="faq-question">Is er een eigen ruimte voor vrouwen?<span class="faq-icon">+</span></summary><div class="faq-answer"><p>Ja, we hebben een aparte <a href="/ladies-only/">Ladies Only zone</a> beneden in de sportschool. De damesvloer is volledig ingericht met eigen apparatuur en alleen toegankelijk voor vrouwen. Met een Ladies Only abonnement (vanaf €20,50/maand) heb je ook gewoon toegang tot de rest van de gym.</p></div></details>
 

--- a/src/pages/fitness/index.astro
+++ b/src/pages/fitness/index.astro
@@ -9,7 +9,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
 ---
 <Layout
   title="Fitness Culemborg · Onbeperkt vanaf €24,50 · Fitcity Culemborg"
-  description="Fitnessen bij Fitcity Culemborg. Apparatuur van Nautilus, SportsArt en Technogym. Onbeperkt trainen vanaf €24,50/maand. Je eerste proefles is altijd gratis."
+  description="Fitnessen bij Fitcity Culemborg. Onbeperkt trainen vanaf €24,50/maand met professionele apparatuur. Je eerste proefles is altijd gratis."
 >
   <Header />
 
@@ -24,7 +24,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
   <!-- Direct Answer -->
   <section class="content-section scroll-fade-up" data-scroll-reveal>
     <div class="content-narrow">
-      <p class="direct-answer-text">Bij Fitcity Culemborg fitness je op apparatuur van Nautilus, SportsArt en Technogym. Onbeperkt trainen kan vanaf €24,50 per maand met de Smart Deal (12 maanden). Bij elk bezoek helpen de trainers je gratis met je schema of techniek. Je eerste proefles is altijd gratis.</p>
+      <p class="direct-answer-text">Bij Fitcity Culemborg fitness je op professionele apparatuur. Onbeperkt trainen kan vanaf €24,50 per maand met de Smart Deal (12 maanden). Bij elk bezoek helpen de trainers je gratis met je schema of techniek. Je eerste proefles is altijd gratis.</p>
     </div>
   </section>
 
@@ -34,7 +34,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
       <div class="two-col-text-image">
         <div class="col-text">
           <h2 class="sub-heading">WAT KUN JE VERWACHTEN</h2>
-          <p>Bij Fitcity Culemborg train je op een ruime fitnessvloer met apparatuur van drie topmerken. Of je nou wilt afvallen of gewoon lekker actief wilt zijn: je kunt hier elke dag terecht.</p>
+          <p>Bij Fitcity Culemborg train je op een ruime fitnessvloer met professionele apparatuur. Of je nou wilt afvallen of gewoon lekker actief wilt zijn: je kunt hier elke dag terecht.</p>
 
           <h2 class="sub-heading">HOE WERKT HET</h2>
           <p>Je komt binnen wanneer het je uitkomt, pakt je spullen en gaat aan de slag. Weet je niet precies waar je moet beginnen? De trainers staan elke dag klaar om je te helpen met een schema, je techniek te verbeteren of even mee te kijken bij een oefening.</p>
@@ -56,8 +56,8 @@ import MobileCTA from '../../components/MobileCTA.astro';
       <SectionHeading title="WAAROM HIER TRAINEN" />
       <div class="benefits-grid stagger-container">
         <div class="benefit-card hover-lift">
-          <h3>Apparatuur van topmerken</h3>
-          <p>Nautilus, SportsArt en Technogym. Dezelfde merken als bij de grote ketens, in een sportschool waar je de trainers kent.</p>
+          <h3>Professionele apparatuur</h3>
+          <p>Goed onderhouden cardio- en krachtapparatuur en vrije gewichten, in een sportschool waar de trainers je kennen.</p>
         </div>
         <div class="benefit-card hover-lift">
           <h3>Trainers die je helpen</h3>
@@ -103,7 +103,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
       <div class="faq-list">
         <details class="faq-item"><summary class="faq-question">Wat kost fitnessen bij Fitcity Culemborg?<span class="faq-icon">+</span></summary><div class="faq-answer"><p>De Smart Deal kost €24,50 per maand bij een jaarabonnement. Liever meer flexibiliteit? Dan is de Flex €37,00 per maand, maandelijks opzegbaar. Een dagpas kost €7,00. Bij alle abonnementen betaal je eenmalig €17,00 inschrijfkosten.</p></div></details>
         <details class="faq-item"><summary class="faq-question">Krijg ik begeleiding bij het trainen?<span class="faq-icon">+</span></summary><div class="faq-answer"><p>Jazeker! De trainers helpen je met een trainingsschema, corrigeren je techniek en denken mee over je doelen.</p></div></details>
-        <details class="faq-item"><summary class="faq-question">Welke apparatuur hebben jullie?<span class="faq-icon">+</span></summary><div class="faq-answer"><p>We werken met apparatuur van Nautilus, SportsArt en Technogym. Dat zijn merken die je ook bij de grote ketens vindt. De apparatuur wordt regelmatig onderhouden en waar nodig vernieuwd.</p></div></details>
+        <details class="faq-item"><summary class="faq-question">Welke apparatuur hebben jullie?<span class="faq-icon">+</span></summary><div class="faq-answer"><p>De fitnessvloer heeft cardio- en krachtapparatuur en vrije gewichten. Alles wordt regelmatig onderhouden en waar nodig vernieuwd.</p></div></details>
         <details class="faq-item"><summary class="faq-question">Kan ik ook kickboxlessen volgen?<span class="faq-icon">+</span></summary><div class="faq-answer"><p>Ja, met de Ultimate Fit Deal (€37,50/maand) heb je onbeperkt fitness en kickboxlessen. Je kunt ook alleen kickboxen, los van fitness, vanaf €19,95 per maand. Kijk op de <a href="/kickboxing/">kickboxing pagina</a> voor alle opties.</p></div></details>
       </div>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
 ---
 <Layout
   title="Sportschool Culemborg · Fitness vanaf €20,50 · Fitcity Culemborg"
-  description="De meest betaalbare sportschool van Culemborg. Fitness, ladies only en kickboxing. Apparatuur van topmerken. Vanaf €20,50/maand met gratis begeleiding. Je eerste proefles is altijd gratis."
+  description="De meest betaalbare sportschool van Culemborg. Fitness, ladies only en kickboxing. Vanaf €20,50/maand met gratis begeleiding. Je eerste proefles is altijd gratis."
 >
   <Header />
 
@@ -69,7 +69,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
        ============================================ -->
   <section class="direct-answer">
     <div class="direct-answer-inner">
-      <p>Fitcity Culemborg is de sportschool van Culemborg voor fitness, ladies only en kickboxing. Je traint op apparatuur van Nautilus, SportsArt en Technogym, op jouw tempo en met gratis begeleiding bij elk bezoek. Al vanaf €20,50 per maand ben je lid. Je eerste proefles is altijd gratis.</p>
+      <p>Fitcity Culemborg is de sportschool van Culemborg voor fitness, ladies only en kickboxing. Je traint op professionele apparatuur, op jouw tempo en met gratis begeleiding bij elk bezoek. Al vanaf €20,50 per maand ben je lid. Je eerste proefles is altijd gratis.</p>
     </div>
   </section>
 
@@ -88,7 +88,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
           </div>
           <div class="service-card-body">
             <h3 class="service-card-title">Fitness</h3>
-            <p class="service-card-desc">Onbeperkt trainen op apparatuur van topmerken. Train wanneer het jou uitkomt, 7 dagen per week.</p>
+            <p class="service-card-desc">Onbeperkt trainen op professionele apparatuur. Train wanneer het jou uitkomt, 7 dagen per week.</p>
             <a href="/fitness/" class="service-card-link">Meer info →</a>
           </div>
         </div>
@@ -143,7 +143,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
 
           <ul class="vibe-checklist">
             {[
-              'Apparatuur van Nautilus, SportsArt en Technogym',
+              'Professionele apparatuur',
               'Ladies Only zone',
               'Kickboxlessen 3x per week',
               '7 dagen per week open',

--- a/src/pages/over-ons/index.astro
+++ b/src/pages/over-ons/index.astro
@@ -26,7 +26,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
       <div class="two-col-text-image" style="direction: rtl;">
         <div class="col-text" style="direction: ltr;">
           <h2 class="sub-heading">WIE WE ZIJN</h2>
-          <p>Fitcity Culemborg is de sportschool van Culemborg. Fitness, ladies only en kickboxing onder een dak, met apparatuur van Nautilus, SportsArt en Technogym. We zijn geen franchise en geen keten. We zijn een lokale sportschool die draait op goede apparatuur, scherpe prijzen en trainers die je naam kennen. Onze leden trainen hier elke week, en dat is precies groot genoeg.</p>
+          <p>Fitcity Culemborg is de sportschool van Culemborg. Fitness, ladies only en kickboxing onder een dak. We zijn geen franchise en geen keten. We zijn een lokale sportschool die draait op goede apparatuur, scherpe prijzen en trainers die je naam kennen. Onze leden trainen hier elke week, en dat is precies groot genoeg.</p>
         </div>
         <div class="col-image" style="direction: ltr;">
           <img src="/images/fitcity-members.webp" alt="Leden bij Fitcity Culemborg" loading="lazy" style="width: 100%; height: 100%; object-fit: cover; border-radius: 0.5rem;" />


### PR DESCRIPTION
## Summary
Removed all 12 mentions of Nautilus, SportsArt, Technogym, and "topmerken" across 4 pages. Replaced with "professionele apparatuur" where needed.

**Files changed:** index.astro, fitness/index.astro, over-ons/index.astro, faq/index.astro

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)