### PR TITLE
Remove 'voor alle niveaus' from bokszaktraining

### DIFF
--- a/src/pages/fitness/index.astro
+++ b/src/pages/fitness/index.astro
@@ -125,7 +125,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
       <p class="related-heading">Ook interessant</p>
       <div class="related-links">
         <a href="/ladies-only/" class="related-link">Ladies Only <span>Fitness voor vrouwen</span></a>
-        <a href="/kickboxing/" class="related-link">Bokszaktraining <span>Training voor alle niveaus</span></a>
+        <a href="/kickboxing/" class="related-link">Bokszaktraining <span>Training met begeleiding</span></a>
       </div>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -112,7 +112,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
           </div>
           <div class="service-card-body">
             <h3 class="service-card-title">Bokszaktraining</h3>
-            <p class="service-card-desc">Bokszaktraining voor alle niveaus. Train op eigen tempo aan de bokszakken. Geen ervaring nodig, gewoon komen en doen.</p>
+            <p class="service-card-desc">Train aan de bokszakken onder begeleiding. Werk aan je kracht, conditie en techniek.</p>
             <a href="/kickboxing/" class="service-card-link">Meer info →</a>
           </div>
         </div>
@@ -257,7 +257,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
     <div class="kickboxing-container">
       <SectionHeading eyebrow="BOKSZAKTRAINING" title="WORD STERKER" />
 
-      <p class="kickboxing-body">Bokszaktraining voor alle niveaus. Train op eigen tempo aan de bokszakken en werk aan je kracht, conditie en techniek.</p>
+      <p class="kickboxing-body">Train aan de bokszakken onder begeleiding en werk aan je kracht, conditie en techniek.</p>
 
       <p class="kickboxing-schedule">Di 19:00 · Do 19:00</p>
 

--- a/src/pages/kickboxing/index.astro
+++ b/src/pages/kickboxing/index.astro
@@ -8,7 +8,7 @@ import Footer from '../../components/Footer.astro';
 import MobileCTA from '../../components/MobileCTA.astro';
 ---
 <Layout
-  title="Bokszaktraining Culemborg · Voor alle niveaus · Fitcity Culemborg"
+  title="Bokszaktraining Culemborg · Training met begeleiding · Fitcity Culemborg"
   description="Bokszaktraining bij Fitcity Culemborg. Train aan de bokszakken op dinsdag en donderdag om 19:00. Vanaf €19,95/maand of incl. fitness €37,50. Je eerste proeftraining is gratis."
 >
   <Header />

--- a/src/pages/ladies-only/index.astro
+++ b/src/pages/ladies-only/index.astro
@@ -90,7 +90,7 @@ import MobileCTA from '../../components/MobileCTA.astro';
 
   <CtaSection title="PROBEER HET ZELF" text="Je eerste proefles is altijd gratis. Neem gerust contact op, of word direct lid." primaryLabel="WORD NU LID" primaryHref="/signup/" secondaryLabel="PLAN PROEFTRAINING" secondaryHref="/contact/?onderwerp=proeftraining#contact-form" />
 
-  <section class="content-section"><div class="content-wide"><p class="related-heading">Ook interessant</p><div class="related-links"><a href="/fitness/" class="related-link">Fitness <span>Onbeperkt trainen</span></a><a href="/kickboxing/" class="related-link">Bokszaktraining <span>Training voor alle niveaus</span></a></div></div></section>
+  <section class="content-section"><div class="content-wide"><p class="related-heading">Ook interessant</p><div class="related-links"><a href="/fitness/" class="related-link">Fitness <span>Onbeperkt trainen</span></a><a href="/kickboxing/" class="related-link">Bokszaktraining <span>Training met begeleiding</span></a></div></div></section>
 
   <Footer />
   <MobileCTA />


### PR DESCRIPTION
## Summary
- Removes filler text "voor alle niveaus" from all bokszaktraining descriptions
- Replaces with "training met begeleiding" where a subtitle is needed
- Updates page title tag on bokszaktraining page

## Test plan
- [ ] Check homepage service card text
- [ ] Check homepage gallery section text
- [ ] Check related links on fitness and ladies-only pages
- [ ] Check bokszaktraining page title in browser tab

Closes #40

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)