### PR TITLE
Remove 'gratis begeleiding' from homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
 ---
 <Layout
   title="Sportschool Culemborg · Fitness vanaf €20,50 · Fitcity Culemborg"
-  description="De meest betaalbare sportschool van Culemborg. Fitness, ladies only en bokszaktraining. Vanaf €20,50/maand met gratis begeleiding. Je eerste proefles is altijd gratis."
+  description="De meest betaalbare sportschool van Culemborg. Fitness, ladies only en bokszaktraining. Vanaf €20,50/maand. Je eerste proefles is altijd gratis."
 >
   <Header />
 
@@ -69,7 +69,7 @@ import { pricingPlans, pricingExtras } from '../data/pricing';
        ============================================ -->
   <section class="direct-answer">
     <div class="direct-answer-inner">
-      <p>Fitcity Culemborg is de sportschool van Culemborg voor fitness, ladies only en bokszaktraining. Je traint op professionele apparatuur, op jouw tempo en met gratis begeleiding bij elk bezoek. Al vanaf €20,50 per maand ben je lid. Je eerste proefles is altijd gratis.</p>
+      <p>Fitcity Culemborg is de sportschool van Culemborg voor fitness, ladies only en bokszaktraining. Je traint op professionele apparatuur, op jouw tempo en met begeleiding. Al vanaf €20,50 per maand ben je lid. Je eerste proefles is altijd gratis.</p>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Removes redundant "gratis" before "begeleiding" in intro paragraph
- Removes "met gratis begeleiding" from meta description

Closes #42

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)